### PR TITLE
Fix Columns → Horizontal Scrolling crash

### DIFF
--- a/imgui.js
+++ b/imgui.js
@@ -2218,7 +2218,7 @@ System.register(["./bind-imgui", "./imconfig"], function (exports_1, context_1) 
                 // If you don't specify an items_height, you NEED to call Step(). If you specify items_height you may call the old Begin()/End() api directly, but prefer calling Step().
                 // ImGuiListClipper(int items_count = -1, float items_height = -1.0f)  { Begin(items_count, items_height); } // NB: Begin() initialize every fields (as we allow user to call Begin/End multiple times on a same instance if they want).
                 constructor(items_count = -1, items_height = -1.0) {
-                    this.native = new Bind.ImGuiListClipper(items_count, items_height);
+                    this.native = new bind.ImGuiListClipper(items_count, items_height);
                 }
                 // ~ImGuiListClipper()                                                 { IM_ASSERT(ItemsCount == -1); }      // Assert if user forgot to call End() or Step() until false.
                 delete() {
@@ -2241,7 +2241,7 @@ System.register(["./bind-imgui", "./imconfig"], function (exports_1, context_1) 
                 // IMGUI_API void Begin(int items_count, float items_height = -1.0f);  // Automatically called by constructor if you passed 'items_count' or by Step() in Step 1.
                 Begin(items_count, items_height) {
                     if (!this.native) {
-                        this.native = new Bind.ImGuiListClipper(items_count, items_height);
+                        this.native = new bind.ImGuiListClipper(items_count, items_height);
                     }
                     this.native.Begin(items_count, items_height);
                 }

--- a/imgui.ts
+++ b/imgui.ts
@@ -890,7 +890,7 @@ export class ImGuiListClipper
     // If you don't specify an items_height, you NEED to call Step(). If you specify items_height you may call the old Begin()/End() api directly, but prefer calling Step().
     // ImGuiListClipper(int items_count = -1, float items_height = -1.0f)  { Begin(items_count, items_height); } // NB: Begin() initialize every fields (as we allow user to call Begin/End multiple times on a same instance if they want).
     constructor(items_count: number = -1, items_height: number = -1.0) {
-        this.native = new Bind.ImGuiListClipper(items_count, items_height);
+        this.native = new bind.ImGuiListClipper(items_count, items_height);
     }
     // ~ImGuiListClipper()                                                 { IM_ASSERT(ItemsCount == -1); }      // Assert if user forgot to call End() or Step() until false.
     public delete(): void {
@@ -912,7 +912,7 @@ export class ImGuiListClipper
     // IMGUI_API void Begin(int items_count, float items_height = -1.0f);  // Automatically called by constructor if you passed 'items_count' or by Step() in Step 1.
     public Begin(items_count: number, items_height: number): void {
         if (!this.native) {
-            this.native = new Bind.ImGuiListClipper(items_count, items_height);
+            this.native = new bind.ImGuiListClipper(items_count, items_height);
         }
         this.native.Begin(items_count, items_height);
     }


### PR DESCRIPTION
Right now, this application crashes when looking at Columns → Horizontal Scrolling with this error message:
```
Uncaught TypeError: Bind.ImGuiListClipper is not a constructor
    at new ImGuiListClipper (imgui.ts:893)
    at Object.ShowDemoWindow (imgui_demo.ts:1815)
    at _loop (main.ts:157)
```
Changing ```new Bind.ImGuiListClipper()``` to ```new bind.ImGuiListClipper()``` appears to fix it. (I only tested this in DevTools, I didn't rebuild the app)

Also, the Github online editor automatically inserts a final newline into the transpiled .js file, hope that's not a problem.