### PR TITLE
Share texture atlases across contexts

### DIFF
--- a/bind-imgui.cpp
+++ b/bind-imgui.cpp
@@ -153,7 +153,7 @@ public:
     emscripten::val _ImGui_SetAllocatorFunctions_user_data = emscripten::val::undefined();
 
 public:
-    WrapImGuiContext(ImFontAtlas* shared_font_atlas = NULL): ctx(ImGui::CreateContext()) {
+    WrapImGuiContext(ImFontAtlas* shared_font_atlas = NULL): ctx(ImGui::CreateContext(shared_font_atlas)) {
         ImGuiContext* prev_ctx = ImGui::GetCurrentContext();
         ImGui::SetCurrentContext(ctx);
         ImGuiIO& io = ImGui::GetIO();
@@ -1600,8 +1600,8 @@ EMSCRIPTEN_BINDINGS(ImGui) {
     // All contexts share a same ImFontAtlas by default. If you want different font atlas, you can new() them and overwrite the GetIO().Fonts variable of an ImGui context.
     // All those functions are not reliant on the current context.
     // IMGUI_API ImGuiContext* CreateContext(ImFontAtlas* shared_font_atlas = NULL);
-    emscripten::function("CreateContext", FUNCTION(WrapImGuiContext*, (), {
-        return WrapImGuiContext::CreateContext(); // TODO: shared font atlas
+    emscripten::function("CreateContext", FUNCTION(WrapImGuiContext*, (ImFontAtlas* atlas), {
+        return WrapImGuiContext::CreateContext(atlas); // TODO: shared font atlas
     }), emscripten::allow_raw_pointers());
     // IMGUI_API void          DestroyContext(ImGuiContext* ctx = NULL);   // NULL = Destroy current context
     emscripten::function("DestroyContext", FUNCTION(void, (WrapImGuiContext* wrap), {

--- a/bind-imgui.d.ts
+++ b/bind-imgui.d.ts
@@ -958,7 +958,7 @@ ImGuiStyle: { new(): ImGuiStyle; };
 // All contexts share a same ImFontAtlas by default. If you want different font atlas, you can new() them and overwrite the GetIO().Fonts variable of an ImGui context.
 // All those functions are not reliant on the current context.
 // IMGUI_API ImGuiContext* CreateContext(ImFontAtlas* shared_font_atlas = NULL);
-CreateContext(): WrapImGuiContext;
+CreateContext(shared_font_atlas: reference_ImFontAtlas | null): WrapImGuiContext;
 // IMGUI_API void          DestroyContext(ImGuiContext* ctx = NULL);   // NULL = Destroy current context
 DestroyContext(ctx: WrapImGuiContext | null): void;
 // IMGUI_API ImGuiContext* GetCurrentContext();


### PR DESCRIPTION
Hook up the function arguments to ImGuiContext that allow us to share texture atlases, and make the textureById cache global, so we share those font textures across contexts.

TODO: do we want separate shared/context-dependent texture lookups? This change forces us to share *all* textures (is there a downside to that?)